### PR TITLE
Fix Spyder color formatting

### DIFF
--- a/cpylog/utils.py
+++ b/cpylog/utils.py
@@ -13,7 +13,7 @@ def ipython_info() -> Optional[str]:
 
         # Spyder doesn't support HTML objects.
         # Check for spyder in order to fall back on Colorama
-        if 'SPY_PYTHONPATH' in os.environ:
+        if ipython.__class__.__name__ == "SpyderShell":
             return None
         return ipython
     except NameError:


### PR DESCRIPTION
Hi Steve,

Since my last pull request, Spyder has a more robust way to check if code is running inside it. I've updated the Spyder detection. This works on my machine with the latest Spyder (6.1.3). 

Before:
<img width="1822" height="168" alt="image" src="https://github.com/user-attachments/assets/a7862b53-7d71-4f48-9a1f-82ca7ba2caeb" />

After:
<img width="1704" height="145" alt="image" src="https://github.com/user-attachments/assets/1163bb1d-7604-4456-b7e6-3e4b14d1109e" />
